### PR TITLE
Fix enemy guns flickering after player death

### DIFF
--- a/RelicHuntersZero.gmx/objects/class_gun_enemy.object.gmx
+++ b/RelicHuntersZero.gmx/objects/class_gun_enemy.object.gmx
@@ -155,9 +155,10 @@ if instance_exists(owner)
     if instance_exists(owner.ai_target)
     {
         image_angle = point_direction(x,y,owner.ai_target.x,owner.ai_target.y);
+        if owner.look_direction == 0 image_angle = image_angle+180;
     }
     
-    if owner.look_direction == 0 { image_xscale = -1; image_angle = image_angle+180; }
+    if owner.look_direction == 0 image_xscale = -1;
     if owner.look_direction == 1 image_xscale = 1; 
     
     depth = (owner.depth)-1;


### PR DESCRIPTION
Fix a bug where enemies facing left when the player dies would have
their guns flip back and forth due to the lack of an AI target, creating
a flickering effect.
